### PR TITLE
Fixed a huge security issue

### DIFF
--- a/ECDHESSwift/Classes/JWK.swift
+++ b/ECDHESSwift/Classes/JWK.swift
@@ -28,7 +28,8 @@ enum EcKeyError: Error {
 
 public extension ECPrivateKey {
     func getPublic() -> ECPublicKey {
-        return ECPublicKey(crv: crv, x: x, y: y, additionalParameters: parameters)
+        let parametersForPublic = parameters.filter { $0.key != ECParameter.privateKey.rawValue }
+        return ECPublicKey(crv: crv, x: x, y: y, additionalParameters: parametersForPublic)
     }
 
     func isCorrespondWith(_ key: ECPublicKey) -> Bool {


### PR DESCRIPTION
Fixed security problem: method getPublic() from extension ECPrivateKey returned ECPublicKey with private part in parameters.
 - Warning: additionalParameters (in ECPublicKey.init) is not equal as ECPrivateKey.parameters. JOSESwift documentation: ECPublicKey.init additionalParameters "parameters: Additional JWK parameters." and ECPrivateKey.parameters "The JWK parameters." that is, INCLUDING PRIVATE PART!!!