### PR TITLE
upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: objective-c
 
-osx_image: xcode10.2
+osx_image: xcode11.6
 
 env:
   matrix:
-    - TEST_SDK=iphonesimulator12.2 OS=12.2 NAME='iPhone XR' CAN_DEPLOY=YES
-    - TEST_SDK=iphonesimulator12.2 OS=10.0 NAME='iPhone 6s Plus'
-    - TEST_SDK=iphonesimulator12.2 OS=10.0 NAME='iPhone 5s'
+    - TEST_SDK=iphonesimulator13.6 OS=13.6 NAME='iPhone 11' CAN_DEPLOY=YES
+    - TEST_SDK=iphonesimulator13.6 OS=10.3.1 NAME='iPhone 6s'
 
 cache: cocoapods
 

--- a/ECDHESSwift.podspec
+++ b/ECDHESSwift.podspec
@@ -38,6 +38,6 @@ Extend JOSESwift 實作 JOSE ECDH-ES 系列 Swift lib
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'JOSESwift', '~> 1.8'
-  s.dependency 'CryptoSwift', '~> 1.4.0'
+  s.dependency 'JOSESwift', '~> 1.8.1'
+  s.dependency 'CryptoSwift', '~> 1.4.1'
 end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,14 +3,14 @@ use_frameworks!
 
 target 'ECDHESSwift_Example' do
   pod 'ECDHESSwift', :path => '../'
-  pod 'JOSESwift', '~> 1.8'
-  pod 'CryptoSwift', '~> 1.4.0'
+  pod 'JOSESwift', '~> 1.8.1'
+  pod 'CryptoSwift', '~> 1.4.1'
 
   target 'ECDHESSwift_Tests' do
     inherit! :search_paths
 
     pod 'FBSnapshotTestCase' , '~> 2.1.4'
-    pod 'Nimble', '~> 8.0.1'
+    pod 'Nimble', '~> 9.2.0'
     pod 'Quick', '~> 2.0.0'
   end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
   - CryptoSwift (1.4.1)
   - ECDHESSwift (0.0.5):
-    - CryptoSwift (~> 1.4.0)
-    - JOSESwift (~> 1.8)
+    - CryptoSwift (~> 1.4.1)
+    - JOSESwift (~> 1.8.1)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
   - JOSESwift (1.8.1)
-  - Nimble (8.0.9)
+  - Nimble (9.2.0)
   - Quick (2.0.0)
 
 DEPENDENCIES:
-  - CryptoSwift (~> 1.4.0)
+  - CryptoSwift (~> 1.4.1)
   - ECDHESSwift (from `../`)
   - FBSnapshotTestCase (~> 2.1.4)
-  - JOSESwift (~> 1.8)
-  - Nimble (~> 8.0.1)
+  - JOSESwift (~> 1.8.1)
+  - Nimble (~> 9.2.0)
   - Quick (~> 2.0.0)
 
 SPEC REPOS:
@@ -34,12 +34,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CryptoSwift: 0bc800a7e6a24c4fc9ebeab97d44b0d5f73a78bd
-  ECDHESSwift: b5536d24240e7862867e517ec39476129da4f9e6
+  ECDHESSwift: 4659b5168474dab0ff887ac2df05dc39c7045acf
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   JOSESwift: 49c6e4497e061e085b9680b84b8cd6b5b64329bd
-  Nimble: 98b888285a615fd34f20e61753cf58ea1402bde4
+  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   Quick: ce1276c7c27ba2da3cb2fd0cde053c3648b3b22d
 
-PODFILE CHECKSUM: baf1a0c69d279c9270ae312339bba44a4e8fedfb
+PODFILE CHECKSUM: 15b3cafdeb38db10a3c3f5aa9d2cbf19b4c8eab0
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
1. Upgrade dependencies
  - CryptoSwift to [1.4.1](https://github.com/krzyzanowskim/CryptoSwift/releases/tag/1.4.1)
  - JOSESwift to [1.8.1](https://github.com/airsidemobile/JOSESwift/releases/tag/1.8.1)
  - Nimble to [v9.2.0](https://github.com/Quick/Nimble/releases/tag/v9.2.0)
2. Upgrade CI  environment
  - xcode upgrade to xcode11.6
  -  matrix:
     - TEST_SDK=iphonesimulator13.6 OS=13.6 NAME='iPhone 11' 
     - TEST_SDK=iphonesimulator13.6 OS=10.3.1 NAME='iPhone 6s'